### PR TITLE
fix: use model key name as default order column

### DIFF
--- a/src/AbstractTable.php
+++ b/src/AbstractTable.php
@@ -184,7 +184,10 @@ abstract class AbstractTable implements JsonSerializable
             return $column;
         }
 
-        return $this->headings->first()['attribute'];
+        /* @var \Illuminate\Database\Eloquent\Model $instance */
+        $instance = app($this->model());
+
+        return $instance->getKeyName();
     }
 
     /**


### PR DESCRIPTION
fix: use model key name as default order column to ensure the order column exists